### PR TITLE
Fix links to the bsc executable

### DIFF
--- a/step7/run.sh
+++ b/step7/run.sh
@@ -17,7 +17,7 @@ mkdir -p _build/reason-js
 # Note: we're using the package name "self" because from our point of view,
 # node_modules is really just another folder filled with files. This produces
 # the right `require` calls in the output.
-node_modules/.bin/bsc -g -bin-annot -pp refmt -bs-package-name self \
+node_modules/bs-platform/bin/bsc.exe -g -bin-annot -pp refmt -bs-package-name self \
   -bs-package-output commonjs:_build/reason-js -o _build/reason-js/ReasonJs \
   -c -impl node_modules/reason-js/src/ReasonJs.re
 
@@ -25,14 +25,14 @@ node_modules/.bin/bsc -g -bin-annot -pp refmt -bs-package-name self \
 mkdir -p _build/self
 # We're adding the `-ppx` flag here (the rest is the same), because BuckleScript
 # uses some ppx preprocessors (basically, macros with special treatment).
-selfSortedFiles=$(ocamldep -ppx ./node_modules/.bin/bsppx -pp refmt -sort -ml-synonym .re src/*.re)
+selfSortedFiles=$(ocamldep -ppx ./node_modules/bs-platform/bin/bsppx.exe -pp refmt -sort -ml-synonym .re src/*.re)
 # should give: src/myDep.re src/myDep2.re src/test.re
 
 for source in $selfSortedFiles
 do
   destination=$(echo $source | sed "s/src/_build\/self/" | sed "s/\.re$//")
   # should give: _build/self/myDep then _build/self/myDep2 then _build/self/test
-  node_modules/.bin/bsc -g -bin-annot -pp refmt -bs-package-name self \
+  node_modules/bs-platform/bin/bsc.exe -g -bin-annot -pp refmt -bs-package-name self \
     -bs-package-output commonjs:_build/self -I _build/self -I _build/reason-js \
     -o $destination -c -impl $source
 done


### PR DESCRIPTION
see https://github.com/bloomberg/bucklescript/issues/790

Looks weird (at least to me) that the executable has `.exe` extension, but it works on my macOS
