### PR TITLE
Fix dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Reason](http://reasonml.github.io/) is a syntax and tooling ecosystem for OCaml. The OCaml's compilation and build system can get rather sophisticated; This repository serves as a tutorial that explains some of the intricacies. It's always nice to know what really happens under the hood!
 
-**Note** that this is for the curious people. You don't need to know these things immediately when you start consuming Reason and the rest. If you just want to try Reason, [this](https://reasonml.github.io/guide/javascript) is the right place to start instead.
+**Note** that this is for the curious people. You don't need to know these things immediately when you start consuming Reason and the rest. If you just want to try Reason, [this](https://reasonml.github.io/docs/en/installation.html) is the right place to start instead.
 
 We start with the most basic OCaml compiler commands and gradually build up to a productive workflow. Each step resides in its independent, fully functional folder.
 
@@ -10,4 +10,4 @@ If you feel certain steps aren't clear, or if you'd like to request a new step, 
 
 ## Requirement
 
-Have Reason >=1.13.5 installed. See [this help page](https://reasonml.github.io/guide/editor-setup)
+Have Reason >=1.13.5 installed. See [this help page](https://reasonml.github.io/docs/en/editor-plugins)


### PR DESCRIPTION
Hello! This page has moved to https://reasonml.github.io/docs/en/installation.html. Please update the URLs to reflect it. Thanks!
https://reasonml.github.io/guide/editor-setup ??? what more that editor plugin ?